### PR TITLE
Support cards with null content

### DIFF
--- a/lib/ankirb/import/apkg.rb
+++ b/lib/ankirb/import/apkg.rb
@@ -69,6 +69,7 @@ module Anki
       # Find every occurence of images, sounds and video, remove
       # them from text, add it to media. Return resulting text
       # and list of media
+      return ['', []] if text == nil
       re = /<img src="(.*?)" *\/>|\[sound:(.*?)\]/
       media = text.scan(re).flatten.reject { |e| e == nil }
       return [text.gsub(re, ''), media]

--- a/test/import_test.rb
+++ b/test/import_test.rb
@@ -25,4 +25,13 @@ class ImportTest < Minitest::Test
       end
     end
   end
+
+  def test_parse_text
+    assert_equal ['text', []], Anki::apkg_importer.parse_text('text')
+    assert_equal ['', ['a.jpg']], Anki::apkg_importer.parse_text('<img src="a.jpg"/>')
+    assert_equal ['text and ', ['a.jpg']], Anki::apkg_importer.parse_text('text and <img src="a.jpg"/>')
+    assert_equal ['text and ', ['a.mp3']], Anki::apkg_importer.parse_text('text and [sound:a.mp3]')
+    assert_equal ['text and ', ['a.mp4']], Anki::apkg_importer.parse_text('text and [sound:a.mp4]')
+    assert_equal ['', []], Anki::apkg_importer.parse_text(nil)
+  end
 end


### PR DESCRIPTION
Previously, the import would crash if it encountered a card with null content on one side. Now, we treat it as an empty text.